### PR TITLE
Remove call to Stop when stopping

### DIFF
--- a/statsview.go
+++ b/statsview.go
@@ -49,11 +49,11 @@ func (vm *ViewManager) Start() {
 
 // Stop shutdown the http server gracefully
 func (vm *ViewManager) Stop() {
-	vm.done <- struct{}{}
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	vm.srv.Shutdown(ctx)
+	//stop the starter goroutine
+	vm.done <- struct{}{}
 }
 
 func init() {

--- a/statsview.go
+++ b/statsview.go
@@ -41,7 +41,6 @@ func (vm *ViewManager) Start() {
 		case <-ticker.C:
 			viewer.StartRTCollect()
 		case <-vm.done:
-			vm.Stop()
 			ticker.Stop()
 			return
 		}


### PR DESCRIPTION
Since the done channel is unbuffered and Start() is meant to be used in a separate goroutine, calling Stop within the goroutine blocks the goroutine from exiting. Not sure if there are other cases I haven't considered.
