### PR TITLE
Optimize: passive polling by HTTP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ $ go get -u github.com/go-echarts/statsview/...
 Statsview is quite simple to use and all static assets have been packaged into the project which makes it possible to run offline. It's worth pointing out that statsview has integrated the standard `net/http/pprof` hence statsview will be the only profiler you need.
 
 ```golang
+package main
+
 import (
     "time"
 
@@ -33,18 +35,16 @@ import (
 )
 
 func main() {
-    go func() {
-        mgr := statsview.New()
+	mgr := statsview.New()
 
-        // Start() runs a HTTP server at `localhost:18066` by default.
-        mgr.Start()
+	// Start() runs a HTTP server at `localhost:18066` by default.
+	go mgr.Start()
 
-        // Stop() will shutdown the http server gracefully
-        // mgr.Stop()
-    }()
+	// Stop() will shutdown the http server gracefully
+	// mgr.Stop()
 
-    // busy working....
-    time.Sleep(time.Minute)
+	// busy working....
+	time.Sleep(time.Minute)
 }
 
 // Visit your browser at http://localhost:18066/debug/statsview

--- a/statsview.go
+++ b/statsview.go
@@ -17,10 +17,9 @@ import (
 
 // ViewManager
 type ViewManager struct {
-	Views []viewer.Viewer
+	srv *http.Server
 
-	srv  *http.Server
-	done chan struct{}
+	Views []viewer.Viewer
 }
 
 // Register registers views to the ViewManager
@@ -38,8 +37,8 @@ func (vm *ViewManager) Stop() {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	vm.srv.Shutdown(ctx)
-	//stop the starter goroutine
-	vm.done <- struct{}{}
+
+	viewer.Quit <- struct{}{}
 }
 
 func init() {
@@ -66,7 +65,6 @@ func New() *ViewManager {
 	page.Assets.JSAssets.Add("jquery.min.js")
 
 	mgr := &ViewManager{
-		done: make(chan struct{}),
 		srv: &http.Server{
 			Addr:           viewer.Addr(),
 			ReadTimeout:    time.Minute,

--- a/statsview.go
+++ b/statsview.go
@@ -23,33 +23,19 @@ type ViewManager struct {
 	done chan struct{}
 }
 
-// Register registers views to the ViweManager
+// Register registers views to the ViewManager
 func (vm *ViewManager) Register(views ...viewer.Viewer) {
 	vm.Views = append(vm.Views, views...)
 }
 
 // Start runs a http server and begin to collect metrics
-func (vm *ViewManager) Start() {
-	ticker := time.NewTicker(time.Duration(viewer.Interval()) * time.Millisecond)
-
-	go func() {
-		vm.srv.ListenAndServe()
-	}()
-
-	for {
-		select {
-		case <-ticker.C:
-			viewer.StartRTCollect()
-		case <-vm.done:
-			ticker.Stop()
-			return
-		}
-	}
+func (vm *ViewManager) Start() error {
+	return vm.srv.ListenAndServe()
 }
 
 // Stop shutdown the http server gracefully
 func (vm *ViewManager) Stop() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	vm.srv.Shutdown(ctx)
 	//stop the starter goroutine

--- a/statsview_test.go
+++ b/statsview_test.go
@@ -1,0 +1,26 @@
+package statsview
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStatsViewMgr(t *testing.T) {
+	mgr := New()
+
+	timeout := time.After(12 * time.Second)
+	done := make(chan bool)
+	go func() {
+		go mgr.Start()
+		time.Sleep(10 * time.Second)
+		mgr.Stop()
+		
+		done <- true
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatal("Test didn't finish in time")
+	case <-done:
+	}
+}

--- a/viewer/gccpufraction.go
+++ b/viewer/gccpufraction.go
@@ -40,9 +40,11 @@ func (vr *GCCPUFractionViewer) View() *charts.Line {
 }
 
 func (vr *GCCPUFractionViewer) Serve(w http.ResponseWriter, _ *http.Request) {
+	rtStats.Tick()
+
 	metrics := Metrics{
-		Values: []float64{fixedPrecision(rtStats.Stats.GCCPUFraction, 6)},
-		Time:   rtStats.T,
+		Values: []float64{fixedPrecision(memstats.Stats.GCCPUFraction, 6)},
+		Time:   memstats.T,
 	}
 
 	bs, _ := json.Marshal(metrics)

--- a/viewer/gcnum.go
+++ b/viewer/gcnum.go
@@ -40,9 +40,11 @@ func (vr *GCNumViewer) View() *charts.Line {
 }
 
 func (vr *GCNumViewer) Serve(w http.ResponseWriter, _ *http.Request) {
+	rtStats.Tick()
+
 	metrics := Metrics{
-		Values: []float64{float64(rtStats.Stats.NumGC)},
-		Time:   rtStats.T,
+		Values: []float64{float64(memstats.Stats.NumGC)},
+		Time:   memstats.T,
 	}
 
 	bs, _ := json.Marshal(metrics)

--- a/viewer/gcsize.go
+++ b/viewer/gcsize.go
@@ -41,12 +41,14 @@ func (vr *GCSizeViewer) View() *charts.Line {
 }
 
 func (vr *GCSizeViewer) Serve(w http.ResponseWriter, _ *http.Request) {
+	rtStats.Tick()
+
 	metrics := Metrics{
 		Values: []float64{
-			fixedPrecision(float64(rtStats.Stats.GCSys)/1024/1024, 2),
-			fixedPrecision(float64(rtStats.Stats.NextGC)/1024/1024, 2),
+			fixedPrecision(float64(memstats.Stats.GCSys)/1024/1024, 2),
+			fixedPrecision(float64(memstats.Stats.NextGC)/1024/1024, 2),
 		},
-		Time: rtStats.T,
+		Time: memstats.T,
 	}
 
 	bs, _ := json.Marshal(metrics)

--- a/viewer/heap.go
+++ b/viewer/heap.go
@@ -43,14 +43,16 @@ func (vr *HeapViewer) View() *charts.Line {
 }
 
 func (vr *HeapViewer) Serve(w http.ResponseWriter, _ *http.Request) {
+	rtStats.Tick()
+
 	metrics := Metrics{
 		Values: []float64{
-			fixedPrecision(float64(rtStats.Stats.HeapAlloc)/1024/1024, 2),
-			fixedPrecision(float64(rtStats.Stats.HeapInuse)/1024/1024, 2),
-			fixedPrecision(float64(rtStats.Stats.HeapSys)/1024/1024, 2),
-			fixedPrecision(float64(rtStats.Stats.HeapIdle)/1024/1024, 2),
+			fixedPrecision(float64(memstats.Stats.HeapAlloc)/1024/1024, 2),
+			fixedPrecision(float64(memstats.Stats.HeapInuse)/1024/1024, 2),
+			fixedPrecision(float64(memstats.Stats.HeapSys)/1024/1024, 2),
+			fixedPrecision(float64(memstats.Stats.HeapIdle)/1024/1024, 2),
 		},
-		Time: rtStats.T,
+		Time: memstats.T,
 	}
 
 	bs, _ := json.Marshal(metrics)

--- a/viewer/stack.go
+++ b/viewer/stack.go
@@ -43,14 +43,16 @@ func (vr *StackViewer) View() *charts.Line {
 }
 
 func (vr *StackViewer) Serve(w http.ResponseWriter, _ *http.Request) {
+	rtStats.Tick()
+
 	metrics := Metrics{
 		Values: []float64{
-			fixedPrecision(float64(rtStats.Stats.StackSys)/1024/1024, 2),
-			fixedPrecision(float64(rtStats.Stats.StackInuse)/1024/1024, 2),
-			fixedPrecision(float64(rtStats.Stats.MSpanSys)/1024/1024, 2),
-			fixedPrecision(float64(rtStats.Stats.MSpanInuse)/1024/1024, 2),
+			fixedPrecision(float64(memstats.Stats.StackSys)/1024/1024, 2),
+			fixedPrecision(float64(memstats.Stats.StackInuse)/1024/1024, 2),
+			fixedPrecision(float64(memstats.Stats.MSpanSys)/1024/1024, 2),
+			fixedPrecision(float64(memstats.Stats.MSpanInuse)/1024/1024, 2),
 		},
-		Time: rtStats.T,
+		Time: memstats.T,
 	}
 
 	bs, _ := json.Marshal(metrics)


### PR DESCRIPTION
ping @xiaochai1027 

Please review this PR. 

Now statsview only calls the `runtime.ReadMemStats` function when receiving the HTTP requests which means that it has no overhead without visiting the `/debug/statsview ` related routes. 

And the `Start` method returns the error hence you can handle it by yourself.