### PR TITLE
Change documentation to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,15 @@ WithTheme(theme Theme)
 
 ```golang
 import (
+	"github.com/go-echarts/statsview"
     "github.com/go-echarts/statsview/viewer"
 )
 
-// set configurations before calling the `Start()` method
+// set configurations before calling `statsview.New()` method
 viewer.SetConfiguration(viewer.WithTheme(viewer.ThemeWesteros), viewer.WithAddr("localhost:8087"))
+
+mgr := statsview.New()
+go mgr.Start()
 ```
 
 ## 🗂 Viewers

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ WithTheme(theme Theme)
 
 ```golang
 import (
-	"github.com/go-echarts/statsview"
+    "github.com/go-echarts/statsview"
     "github.com/go-echarts/statsview/viewer"
 )
 


### PR DESCRIPTION
After debugging for about an hour, i found that i was calling 

```golang
mgr := statsview.New()
viewer.setConfiguration(viewer.WithAddr("192.168.1.2:18066"))
go mgr.Start()
```

which created unexpected results, example a log message on statsview.go#36
```golang
func (vm *ViewManager) Start() error {
    fmt.Printf("Server Addr: %s Expected: %v\n", vm.srv.Addr, viewer.Addr()) // Server Addr: localhost:18066 Expected: 192.168.1.2:18066
    return vm.srv.ListenAndServe()
}
```

I want to make sure that the documentation is extremely clear in which the order of the configuration is called.